### PR TITLE
hide password input config

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -25,6 +25,7 @@ colors require the leading `#` and all options have to be wrapped in quotation m
 - `FieldBorderColor`: border color of selected field. not visible if width is 0.
 - `UserFieldBgText`: placeholder text shown when user field is empty.
 - `PassFieldBgText`: placeholder text shown when password field is empty.
+- `PassHideInput`: immediately mask text input in the password field.
 
 ## login button
 

--- a/corners/components/PasswordPanel.qml
+++ b/corners/components/PasswordPanel.qml
@@ -9,7 +9,7 @@ TextField {
     placeholderText: config.PassFieldBgText
     echoMode: TextInput.Password
     passwordCharacter: "•"
-    passwordMaskDelay: 1000
+    passwordMaskDelay: config.PassHideInput == "true" ? 0 : 1000
     selectionColor: config.FieldText
     renderType: Text.NativeRendering
     font.family: config.Font

--- a/corners/theme.conf
+++ b/corners/theme.conf
@@ -51,6 +51,8 @@ UAPColor="#cdd6f4"
 # UserFieldBgText:  placeholder text shown when user field is empty.
 #
 # PassFieldBgText:  placeholder text shown when password field is empty.
+#
+# PassHideInput:  immediately mask text input in the password field.
 
 FieldBackground="#1e1e2e"
 FieldText="#cdd6f4"
@@ -58,6 +60,7 @@ FieldBorderWidth="3"
 FieldBorderColor="#b4befe"
 UserFieldBgText="enter username"
 PassFieldBgText="enter password"
+PassHideInput="false"
 
 ### LOGIN BUTTON
 #


### PR DESCRIPTION
Adds a config to allow hiding the password input completely for heightened security. Keeps previous setting as default.